### PR TITLE
Compatibility with Ruby 2.2 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# ruby '1.9.3'
+ruby '2.2.3'
 
 gem 'dashing'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       thin (~> 1.6.1)
       thor (~> 0.18.1)
     equalizer (0.0.9)
-    eventmachine (1.0.3)
+    eventmachine (1.0.8)
     execjs (2.0.2)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)


### PR DESCRIPTION
Update EventMachine gem to make it work with Ruby 2.2